### PR TITLE
Rename `omf use` to `omf theme`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Update framework and installed packages.
 
 ## `omf get` _`<package> ...`_
 
-Install one _or more_ themes or packages. To list available packages type `omf use`.
+Install one _or more_ themes or packages. To list available packages type `omf theme`.
 
 > You can fetch packages by URL as well via `omf get URL`
 
@@ -93,9 +93,9 @@ List installed packages.
 
 > To list packages available for download use `omf get`.
 
-## `omf use` _`<theme>`_
+## `omf theme` _`<theme>`_
 
-Apply a theme. To list available themes type `omf use`.
+Apply a theme. To list available themes type `omf theme`.
 
 ## `omf remove` _`<name>`_
 

--- a/pkg/omf/cli/omf_help.fish
+++ b/pkg/omf/cli/omf_help.fish
@@ -6,7 +6,7 @@ function omf_help
   "(omf::dim)"Actions"(omf::off)"
        "(omf::em)"l"(omf::off)"ist  List local packages.
         "(omf::em)"g"(omf::off)"et  Install one or more packages.
-        "(omf::em)"u"(omf::off)"se  List / Apply themes.
+      "(omf::em)"t"(omf::off)"heme  List / Use themes.
      "(omf::em)"r"(omf::off)"emove  Remove a theme or package.
      u"(omf::em)"p"(omf::off)"date  Update Oh My Fish.
         "(omf::em)"n"(omf::off)"ew  Create a new package from a template.

--- a/pkg/omf/cli/omf_theme.fish
+++ b/pkg/omf/cli/omf_theme.fish
@@ -1,4 +1,4 @@
-function omf_use
+function omf_theme
   if not test -e $OMF_CUSTOM/themes/$argv[1]
     if not test -e $OMF_PATH/themes/$argv[1]
       set -l theme $OMF_PATH/db/themes/$argv[1]

--- a/pkg/omf/completions/omf.fish
+++ b/pkg/omf/completions/omf.fish
@@ -15,11 +15,11 @@ complete --no-files -c omf -d "Oh My Fish"
 complete -c omf -n "__omf_opt_is q query"      -a (printf "%s " (set | awk '{ printf $1"\n"; }'))
 complete -c omf -n "__omf_opt_is r rm remove"  -a (printf "%s " (omf_list_local_packages) (omf_list_installed_themes))
 complete -c omf -n "__omf_opt_is g get"        -a (printf "%s " (omf_list_db_packages))
-complete -c omf -n "__omf_opt_is u use"        -a (printf "%s " (omf_list_themes))
+complete -c omf -n "__omf_opt_is t theme"      -a (printf "%s " (omf_list_themes))
 
 complete -c omf -a list    -n "__omf_is_single_opt" -d "List local packages"
 complete -c omf -a get     -n "__omf_is_single_opt" -d "Install one or more packages"
-complete -c omf -a use     -n "__omf_is_single_opt" -d "List / Apply themes"
+complete -c omf -a theme   -n "__omf_is_single_opt" -d "List / Use themes"
 complete -c omf -a remove  -n "__omf_is_single_opt" -d "Remove a theme or package"
 complete -c omf -a update  -n "__omf_is_single_opt" -d "Update Oh My Fish"
 complete -c omf -a new     -n "__omf_is_single_opt" -d "Create a new package from a template"

--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -59,7 +59,7 @@ function omf -d "Oh My Fish"
         omf_get_package $argv[2..-1]
       end
 
-    case "u" "use"
+    case "t" "theme"
       if test (count $argv) -eq 1
         set -l theme (cat $OMF_CONFIG/theme)
         set -l regex "[[:<:]]($theme)[[:>:]]"
@@ -69,7 +69,7 @@ function omf -d "Oh My Fish"
         omf::off
 
       else if test (count $argv) -eq 2
-        omf_use $argv[2]
+        omf_theme $argv[2]
       else
         echo (omf::err)"Invalid number of arguments"(omf::off) 1^&2
         echo "Usage: $_ "(omf::em)"$argv[1]"(omf::off)" [<theme name>]" 1^&2
@@ -93,7 +93,7 @@ function omf -d "Oh My Fish"
         echo (omf::err)"Oh My Fish failed to update."(omf::off)
         echo "Please open a new issue here → "(omf::em)"git.io/omf-issues"(omf::off)
       end
-      omf_use (cat $OMF_CONFIG/theme)
+      omf_theme (cat $OMF_CONFIG/theme)
       omf_get_package (omf_list_installed_packages)
       popd
       refresh


### PR DESCRIPTION
The first time I saw `use`, I thought I could use the command for
everything, including packages, but it's only used for themes. So, it's
better to have a clearer name.