### PR TITLE
Current in use theme should not be deletable

### DIFF
--- a/pkg/omf/cli/omf_list_installed_packages.fish
+++ b/pkg/omf/cli/omf_list_installed_packages.fish
@@ -1,6 +1,6 @@
 # List all packages installed from the registry.
 function omf_list_installed_packages
-  for item in (basename $OMF_PATH/pkg/*)
+  for item in (basename -a $OMF_PATH/pkg/*)
     test $item = wa; or echo $item
   end
 end

--- a/pkg/omf/cli/omf_list_installed_packages.fish
+++ b/pkg/omf/cli/omf_list_installed_packages.fish
@@ -1,6 +1,6 @@
 # List all packages installed from the registry.
 function omf_list_installed_packages
   for item in (basename -a $OMF_PATH/pkg/*)
-    test $item = wa; or echo $item
+    test $item = omf; or echo $item
   end
 end

--- a/pkg/omf/cli/omf_list_installed_themes.fish
+++ b/pkg/omf/cli/omf_list_installed_themes.fish
@@ -1,5 +1,7 @@
 function omf_list_installed_themes
-  for item in (basename $OMF_PATH/themes/*)
-    test $item = default; or echo $item
+  set -l default (cat $OMF_CONFIG/theme)
+
+  for item in (basename -a $OMF_PATH/themes/*)
+    test $item = $default; or echo $item
   end
 end

--- a/pkg/omf/cli/omf_list_local_packages.fish
+++ b/pkg/omf/cli/omf_list_local_packages.fish
@@ -1,6 +1,6 @@
 # List all custom packages and packages installed from the registry.
 function omf_list_local_packages
   for item in (basename {$OMF_PATH,$OMF_CUSTOM}/pkg/*)
-    test $item = wa; or echo $item
+    test $item = omf; or echo $item
   end
 end


### PR DESCRIPTION
Get default theme by reading from $OMG_CONFIG/theme file and skip it
from the list of installed themes.

There is a bug with `basename`, notice how 'led' is not displayed on
`basename` call:

```
omf:fix-omf-remove* λ ls $OMF_PATH/themes/
l   led
omf:fix-omf-remove* λ basename $OMF_PATH/themes/*
l
```