### PR TITLE
Current in use theme should not be deletable

### DIFF
--- a/pkg/omf/cli/omf_list_installed_themes.fish
+++ b/pkg/omf/cli/omf_list_installed_themes.fish
@@ -1,5 +1,3 @@
 function omf_list_installed_themes
-  for item in (basename $OMF_PATH/themes/*)
-    test $item = default; or echo $item
-  end
+  basename $OMF_PATH/themes/*
 end


### PR DESCRIPTION
Get default theme by reading from $OMG_CONFIG/theme file and skip it
from the list of installed themes.