### PR TITLE
Rename 'get' to 'install'

### DIFF
--- a/pkg/omf/cli/omf_help.fish
+++ b/pkg/omf/cli/omf_help.fish
@@ -5,10 +5,10 @@ function omf_help
 
   "(omf::dim)"Actions"(omf::off)"
        "(omf::em)"l"(omf::off)"ist  List local packages.
-        "(omf::em)"g"(omf::off)"et  Install one or more packages.
+    "(omf::em)"i"(omf::off)"nstall  Install one or more packages.
       "(omf::em)"t"(omf::off)"heme  List / Use themes.
      "(omf::em)"r"(omf::off)"emove  Remove a theme or package.
-     u"(omf::em)"p"(omf::off)"date  Update Oh My Fish.
+     "(omf::em)"u"(omf::off)"pdate  Update Oh My Fish.
         "(omf::em)"n"(omf::off)"ew  Create a new package from a template.
      "(omf::em)"s"(omf::off)"ubmit  Submit a package to the registry.
       "(omf::em)"q"(omf::off)"uery  Query environment variables.

--- a/pkg/omf/cli/omf_install_package.fish
+++ b/pkg/omf/cli/omf_install_package.fish
@@ -1,4 +1,4 @@
-function omf_get_package
+function omf_install_package
   for search in $argv
     if test -e $OMF_PATH/db/pkg/$search
       set target pkg/$search

--- a/pkg/omf/completions/omf.fish
+++ b/pkg/omf/completions/omf.fish
@@ -14,11 +14,11 @@ complete --no-files -c omf -d "Oh My Fish"
 
 complete -c omf -n "__omf_opt_is q query"      -a (printf "%s " (set | awk '{ printf $1"\n"; }'))
 complete -c omf -n "__omf_opt_is r rm remove"  -a (printf "%s " (omf_list_local_packages) (omf_list_installed_themes))
-complete -c omf -n "__omf_opt_is g get"        -a (printf "%s " (omf_list_db_packages))
+complete -c omf -n "__omf_opt_is i install"    -a (printf "%s " (omf_list_db_packages))
 complete -c omf -n "__omf_opt_is t theme"      -a (printf "%s " (omf_list_themes))
 
 complete -c omf -a list    -n "__omf_is_single_opt" -d "List local packages"
-complete -c omf -a get     -n "__omf_is_single_opt" -d "Install one or more packages"
+complete -c omf -a install -n "__omf_is_single_opt" -d "Install one or more packages"
 complete -c omf -a theme   -n "__omf_is_single_opt" -d "List / Use themes"
 complete -c omf -a remove  -n "__omf_is_single_opt" -d "Remove a theme or package"
 complete -c omf -a update  -n "__omf_is_single_opt" -d "Update Oh My Fish"

--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -52,11 +52,11 @@ function omf -d "Oh My Fish"
     case "l" "li" "lis" "lst" "list"
       omf_list_local_packages | column
 
-    case "g" "ge" "get" "install"
+    case "i" "install" "get"
       if test (count $argv) -eq 1
         omf_list_db_packages | column
       else
-        omf_get_package $argv[2..-1]
+        omf_install_package $argv[2..-1]
       end
 
     case "t" "theme"
@@ -84,7 +84,7 @@ function omf -d "Oh My Fish"
       end
       omf_remove_package $argv[2..-1]
 
-    case "p" "up" "upd" "update"
+    case "u" "up" "upd" "update"
       pushd $OMF_PATH
       echo (omf::em)"Updating Oh My Fish..."(omf::off)
       if omf_update
@@ -94,7 +94,7 @@ function omf -d "Oh My Fish"
         echo "Please open a new issue here → "(omf::em)"git.io/omf-issues"(omf::off)
       end
       omf_theme (cat $OMF_CONFIG/theme)
-      omf_get_package (omf_list_installed_packages)
+      omf_install_package (omf_list_installed_packages)
       popd
       refresh
 


### PR DESCRIPTION
We already use 'install' on the command description: 'Install one or
more packages.'

Also call update using 'u' instead of 'p'.