### PR TITLE
No refresh on install or theme

### DIFF
--- a/pkg/omf/cli/omf_install_package.fish
+++ b/pkg/omf/cli/omf_install_package.fish
@@ -30,5 +30,4 @@ function omf_install_package
         or echo (omf::err)"Could not install package."(omf::off) 1^&2
     end
   end
-  refresh
 end

--- a/pkg/omf/cli/omf_theme.fish
+++ b/pkg/omf/cli/omf_theme.fish
@@ -14,5 +14,4 @@ function omf_theme
     end
   end
   echo "$argv[1]" > $OMF_CONFIG/theme
-  refresh
 end

--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -57,6 +57,7 @@ function omf -d "Oh My Fish"
         omf_list_db_packages | column
       else
         omf_install_package $argv[2..-1]
+        refresh
       end
 
     case "t" "theme"
@@ -70,6 +71,7 @@ function omf -d "Oh My Fish"
 
       else if test (count $argv) -eq 2
         omf_theme $argv[2]
+        refresh
       else
         echo (omf::err)"Invalid number of arguments"(omf::off) 1^&2
         echo "Usage: $_ "(omf::em)"$argv[1]"(omf::off)" [<theme name>]" 1^&2


### PR DESCRIPTION
This should fix the execution halting problem in `omf update` because it leaves refreshing up to the caller of `omf_install_package` and `omf_theme`.