### PR TITLE
describe command

### DIFF
--- a/pkg/omf/cli/omf.describe.fish
+++ b/pkg/omf/cli/omf.describe.fish
@@ -1,0 +1,17 @@
+function omf.describe -a name
+  if test (count $argv) -eq 0
+    for package in (omf.list_db_packages)
+      echo $package - (omf.describe $package)
+    end
+  else
+    set package_path $OMF_PATH/db/pkg/$name
+    if test -e $package_path
+      set url (cat $package_path)
+      set repo (basename (dirname $url))/(basename $url)
+      curl -s https://api.github.com/repos/$repo | ruby -rjson -e 'j = JSON.parse(ARGF.read); puts j["description"]'
+    else
+      echo (omf::err)"$name is not a valid pkg."(omf::off) 1^&2
+      return $OMF_INVALID_ARG
+    end
+  end
+end

--- a/pkg/omf/cli/omf.help.fish
+++ b/pkg/omf/cli/omf.help.fish
@@ -5,6 +5,7 @@ function omf.help
 
   "(omf::dim)"Actions"(omf::off)"
          "(omf::em)"l"(omf::off)"ist  List local packages.
+     "(omf::em)"d"(omf::off)"escribe  Get information about what packages do.
       "(omf::em)"i"(omf::off)"nstall  Install one or more packages.
         "(omf::em)"t"(omf::off)"heme  List / Use themes.
        "(omf::em)"r"(omf::off)"emove  Remove a theme or package.

--- a/pkg/omf/completions/omf.fish
+++ b/pkg/omf/completions/omf.fish
@@ -12,19 +12,23 @@ end
 
 complete --no-files -c omf -d "Oh My Fish"
 
-complete -c omf -n "__omf.opt_is q query"      -a (printf "%s " (set | awk '{ printf $1"\n"; }'))
-complete -c omf -n "__omf.opt_is r rm remove"  -a (printf "%s " (omf.list_local_packages) (omf.list_installed_themes))
-complete -c omf -n "__omf.opt_is i install"    -a (printf "%s " (omf.list_db_packages))
-complete -c omf -n "__omf.opt_is t theme"      -a (printf "%s " (omf.list_themes))
+complete -c omf -n "__omf.opt_is q query"         -a (printf "%s " (set | awk '{ printf $1"\n"; }'))
+complete -c omf -n "__omf.opt_is r rm remove"     -a (printf "%s " (omf.list_local_packages) (omf.list_installed_themes))
+complete -c omf -n "__omf.opt_is d desc describe" -a (printf "%s " (omf.list_db_packages))
+complete -c omf -n "__omf.opt_is c cd"            -a (printf "%s " (omf.list_db_packages))
+complete -c omf -n "__omf.opt_is i install"       -a (printf "%s " (omf.list_db_packages))
+complete -c omf -n "__omf.opt_is t theme"         -a (printf "%s " (omf.list_themes))
 
-complete -c omf -a list    -n "__omf.is_single_opt" -d "List local packages"
-complete -c omf -a install -n "__omf.is_single_opt" -d "Install one or more packages"
-complete -c omf -a theme   -n "__omf.is_single_opt" -d "List / Use themes"
-complete -c omf -a remove  -n "__omf.is_single_opt" -d "Remove a theme or package"
-complete -c omf -a update  -n "__omf.is_single_opt" -d "Update Oh My Fish"
-complete -c omf -a new     -n "__omf.is_single_opt" -d "Create a new package from a template"
-complete -c omf -a submit  -n "__omf.is_single_opt" -d "Submit a package to the registry"
-complete -c omf -a query   -n "__omf.is_single_opt" -d "Query environment variables"
-complete -c omf -a help    -n "__omf.is_single_opt" -d "Display this help"
-complete -c omf -a version -n "__omf.is_single_opt" -d "Display version"
-complete -c omf -a destroy -n "__omf.is_single_opt" -d "Remove Oh My Fish"
+complete -c omf -a list     -n "__omf.is_single_opt" -d "List local packages"
+complete -c omf -a describe -n "__omf.is_single_opt" -d "Get information about what packages do"
+complete -c omf -a install  -n "__omf.is_single_opt" -d "Install one or more packages"
+complete -c omf -a theme    -n "__omf.is_single_opt" -d "List / Use themes"
+complete -c omf -a remove   -n "__omf.is_single_opt" -d "Remove a theme or package"
+complete -c omf -a update   -n "__omf.is_single_opt" -d "Update Oh My Fish"
+complete -c omf -a cd       -n "__omf.is_single_opt" -d "Change directory to plugin/theme directory"
+complete -c omf -a new      -n "__omf.is_single_opt" -d "Create a new package from a template"
+complete -c omf -a submit   -n "__omf.is_single_opt" -d "Submit a package to the registry"
+complete -c omf -a query    -n "__omf.is_single_opt" -d "Query environment variables"
+complete -c omf -a help     -n "__omf.is_single_opt" -d "Display this help"
+complete -c omf -a version  -n "__omf.is_single_opt" -d "Display version"
+complete -c omf -a destroy  -n "__omf.is_single_opt" -d "Remove Oh My Fish"

--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -72,6 +72,13 @@ function omf -d "Oh My Fish"
     case "l" "li" "lis" "lst" "list"
       omf.list_local_packages | column
 
+    case "d" "desc" "describe"
+      if test (count $argv) -eq 1
+        omf.describe
+      else
+        omf.describe $argv[2..-1]
+      end
+
     case "i" "install" "get"
       if test (count $argv) -eq 1
         omf.list_db_packages | column


### PR DESCRIPTION
Hi

I was struggling to find an easy way to browse all the available packages and find out what they do, so I added an info command to try achieve this.

It pulls the descriptions from the repos on github, so is a little slow. Potentially we could add this info into the local db to make it super quick, but I didn't want to change formats without discussing first.

What do you think?
