### PR TITLE
Do not convert `$HOME` when installing omf.

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -92,7 +92,8 @@ omf_install() {
   touch ${fish_config_file} >/dev/null 2>&1
   test ! -w ${fish_config_file} && die "Fish configuration file is not writable, aborting."
 
-  sed "s|{{OMF_PATH}}|$OMF_PATH|;s|{{OMF_CONFIG}}|$OMF_CONFIG|" \
+  sed "s|{{OMF_PATH}}|$(echo "${OMF_PATH}" | sed -e "s|$HOME|\$HOME|")|;\
+       s|{{OMF_CONFIG}}|$(echo "${OMF_CONFIG}" | sed -e "s|$HOME|\$HOME|")|" \
     "${OMF_PATH}/templates/config.fish" > "${fish_config_file}"
 
   if [ ! -d "${OMF_CONFIG}" ]; then


### PR DESCRIPTION
Keep `$HOME` variable inside `config.fish` when installing oh my fish
instead of converting it to its content.