### PR TITLE
Gives back a way to persist and update installed packages (dotfiles)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,17 +81,16 @@ Oh My Fish includes a small utility `omf` to fetch and install new packages and 
 
 Update framework and installed packages.
 
-## `omf install` _`<package> ...`_
+## `omf install` _`[package|url ...]`_
 
-Install one _or more_ themes or packages. To list available packages type `omf theme`.
+Install one _or more_ packages.
 
-> You can fetch packages by URL as well via `omf install URL`
+- You can install packages directly by URL via `omf install URL`
+- When called without arguments, install missing packages from [bundles](#dotfiles).
 
 ## `omf list`
 
 List installed packages.
-
-> To list packages available for download use `omf install`.
 
 ## `omf theme` _`<theme>`_
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Uninstall Oh My Fish. See [uninstall](#uninstall) for more information.
 
 # :triangular_flag_on_post: Advanced
 + [Startup](#startup)
++ [Dotfiles](#dotfiles)
 + [Core Library](#core-library)
 + [Packages](#packages)
   + [Creating](#creating)
@@ -137,6 +138,18 @@ Uninstall Oh My Fish. See [uninstall](#uninstall) for more information.
 This script runs each time a new session begins, autoloading packages, themes and your _config_ path in that order.
 
 The _config_ path (`~/.config/omf` by default) is defined by `$OMF_CONFIG` in `~/.config/fish/config.fish`. Modify this to load your own configuration, if you have any, as discussed in the [FAQ](FAQ.md#what-does-oh-my-fish-do-exactly).
+
+## Dotfiles
+
+The `$OMF_CONFIG` directory represents the user state of Oh My Fish, and is the perfect
+candidate for being added to your dotfiles and/or checked out to version control. There are two important files:
+
+- __`theme`__ - The current theme
+- __`bundle`__ - List of currently installed packages/themes
+
+### About the bundle
+
+Everytime a package/theme is installed or removed the `bundle` file is updated. You can also edit it manually and run `omf install` afterwards to satisfy the changes. Please note that while packages/themes added to the bundle gets automagically installed, a package/theme removed from bundle isn't removed from user installation.
 
 ## Core Library
 

--- a/bin/install
+++ b/bin/install
@@ -100,7 +100,10 @@ omf_install() {
     echo "Writing Oh My Fish configuration → ${OMF_CONFIG}"
     mkdir -p "${OMF_CONFIG}"
     touch "${OMF_CONFIG}/theme"
+    touch "${OMF_CONFIG}/bundle"
     test -f "${OMF_CONFIG}/revision"  || echo ${git_rev} > "${OMF_CONFIG}/revision"
+  else
+    fish -c "omf install"
   fi
 }
 

--- a/pkg/omf/cli/omf.help.fish
+++ b/pkg/omf/cli/omf.help.fish
@@ -2,10 +2,10 @@ function omf.help -a type_flag
   switch $type_flag
     case "i" "install" "get"
       echo \n"\
-      Install and list packages.
+      Install packages.
 
       "(omf::dim)"Usage:"(omf::off)"
-        omf install                 List available packages to install
+        omf install                 Install missing packages from bundle
         omf install "(omf::em)"<name>"(omf::off)" | "(omf::em)"<url>"(omf::off)"  Install package by name or URL
 
       "(omf::dim)"Examples:"(omf::off)"

--- a/pkg/omf/cli/omf.install.fish
+++ b/pkg/omf/cli/omf.install.fish
@@ -1,4 +1,26 @@
 function omf.install -a type_flag name_or_url
+  function _write_bundle
+    set bundle $OMF_CONFIG/bundle
+    set record $argv
+
+    if test -f $bundle
+      if not grep $record $bundle > /dev/null 2>&1
+        echo $record >> $bundle
+      end
+    else
+      echo $record > $bundle
+    end
+  end
+
+  function _display_success
+    echo (omf::em)"✔ $argv succesfully installed."(omf::off)
+  end
+
+  function _display_error
+    echo (omf::err)"Could not install $argv."(omf::off) 1^&2
+    return $OMF_UNKNOWN_ERR
+  end
+
   switch $type_flag
     case "--theme"
       set install_type "theme"
@@ -19,11 +41,11 @@ function omf.install -a type_flag name_or_url
       echo (omf::err)"Error: $local_name $install_type already installed."(omf::off) 1^&2
     else
       echo (omf::dim)"Trying to clone from URL..."(omf::off)
-      git clone -q $name_or_url $OMF_PATH/$parent_path/$local_name
-      and echo (omf::em)"✔ $local_name $install_type succesfully installed."(omf::off)
-      or begin
-        echo (omf::err)"$local_name is not a valid $install_type."(omf::off) 1^&2
-        return $OMF_INVALID_ARG
+      if git clone -q $name_or_url $OMF_PATH/$parent_path/$local_name
+        _write_bundle "$install_type $name_or_url"
+        _display_success "$install_type $name_or_url"
+      else
+        _display_error "$install_type $name_or_url"
       end
     end
     return 0
@@ -37,11 +59,11 @@ function omf.install -a type_flag name_or_url
     echo (omf::em)"✔ $name_or_url $install_type up to date."(omf::off)
   else
     echo (omf::dim)"Installing $name_or_url $install_type..."(omf::off)
-    git clone (cat $OMF_PATH/db/$target) $OMF_PATH/$target >/dev/null ^&1
-    and echo (omf::em)"✔ $name_or_url $install_type successfully installed."(omf::off)
-    or begin
-      echo (omf::err)"Could not install $install_type."(omf::off) 1^&2
-      return $OMF_UNKNOWN_ERR
+    if git clone (cat $OMF_PATH/db/$target) $OMF_PATH/$target >/dev/null ^&1
+      _write_bundle "$install_type $name_or_url"
+      _display_success "$install_type $name_or_url"
+    else
+      _display_error "$install_type $name_or_url"
     end
   end
 end

--- a/pkg/omf/cli/omf.install_bundle.fish
+++ b/pkg/omf/cli/omf.install_bundle.fish
@@ -1,0 +1,27 @@
+function omf.install_bundle
+
+  if test -f $OMF_CONFIG/bundle
+    set packages (omf.list_local_packages)
+    set themes (omf.list_installed_themes)
+
+    for record in (cat $OMF_CONFIG/bundle)
+      set type (echo $record | cut -d' ' -f1)
+      set name (echo $record | cut -d' ' -f2- | sed -e 's/\.git//')
+
+      switch $type
+      case "package"
+        if not contains (basename $name) $packages
+          omf.install --pkg $name
+        end
+
+      case "theme"
+        if not contains (basename $name) $themes
+          omf.install --theme $name
+        end
+      end
+
+    end
+  end
+
+  return 0
+end

--- a/pkg/omf/cli/omf.remove_package.fish
+++ b/pkg/omf/cli/omf.remove_package.fish
@@ -1,4 +1,28 @@
 function omf.remove_package
+
+  function _remove_from_bundle
+    set bundle $OMF_CONFIG/bundle
+
+    if test -f $bundle
+      set type $argv[1]
+      set name $argv[2]
+      set bundle_contents (cat $bundle)
+
+      rm -f $bundle
+
+      for record in $bundle_contents
+        set record_type (echo $record | cut -d' ' -f1)
+        set record_name (echo $record | cut -d' ' -f2-)
+        set record_basename (basename (echo $record_name | sed -e 's/\.git$//'))
+
+        if not test "$type" = "$record_type" -a "$name" = "$record_basename"
+          echo "$record_type $record_name" >> $bundle
+        end
+
+      end
+    end
+  end
+
   for pkg in $argv
     set -l remove_status 1
 
@@ -15,6 +39,8 @@ function omf.remove_package
       not test -d $path; and continue
 
       emit uninstall_$pkg
+      _remove_from_bundle "package" $pkg
+
       rm -rf $path
       set remove_status $status
     end
@@ -26,16 +52,17 @@ function omf.remove_package
         echo "" > $OMF_CONFIG/theme
       end
 
+      _remove_from_bundle "theme" $pkg
+
       rm -rf $path
       set remove_status $status
     end
 
     if test $remove_status -eq 0
       echo (omf::em)"$pkg succesfully removed."(omf::off)
+      refresh
     else
       echo (omf::err)"$pkg could not be found"(omf::off) 1^&2
     end
   end
-
-  refresh
 end

--- a/pkg/omf/omf.fish
+++ b/pkg/omf/omf.fish
@@ -89,7 +89,7 @@ function omf -d "Oh My Fish"
 
     case "i" "install" "get"
       if test (count $argv) -eq 1
-        omf.list_db_packages "skip installed packages" | column
+        omf.install_bundle
       else
         omf.install_package $argv[2..-1]
         refresh


### PR DESCRIPTION
This PR makes omf cli install from and update a central file declaring installed plugins and themes.

The file is located at `$OMF_CONFIG/bundle`, and is a user-editable text file in the following format:

    package foreign-env
    theme agnoster copy

Blank lines are ignored as do lines that don't start with `package` or `theme`.

What it changes from current cli:

+ `omf install` (without parameters):
  - Looks for all packages declared in bundle file
  - Check what's missing on user installation
  - Install missing packages, satisfying the bundle
+ `omf install [package|theme ...]`
  - The install procedure is unchanged
  - If successful, add the installed package to the bundle (if not already there!)
+ `omf remove [package|theme ...]`
  - The remove procedure is unchanged
  - If successful, remove the installed package from the bundle (if already there!)

On clean installs where `$OMF_CONFIG` exists, the installer will satisfy the bundle before reloading back into fish.
