### PR TITLE
added brew & sublime packages

### DIFF
--- a/db/pkg/brew
+++ b/db/pkg/brew
@@ -1,0 +1,1 @@
+https://github.com/oh-my-fish/plugin-brew

--- a/db/pkg/sublime
+++ b/db/pkg/sublime
@@ -1,0 +1,1 @@
+https://github.com/oh-my-fish/plugin-sublime


### PR DESCRIPTION
noticed the brew package was referenced in the newly added help, but it's not in the package db. added in sublime too.